### PR TITLE
[K8S] Make it easier to get secrets from outside the source tree

### DIFF
--- a/lib/matsuri/kubernetes/secret.rb
+++ b/lib/matsuri/kubernetes/secret.rb
@@ -21,8 +21,10 @@ module Matsuri
       let(:data) { { secret_key => secret_value } }
 
       let(:secret_key)   { fail NotImplementedError, 'Must define let(:secret_key)' }
-      let(:secret_value) { secret_from(secret_path) }
+      let(:secret_value) { secret_from_path(full_secret_path) }
       let(:secret_path)  { fail NotImplementedError, 'Must define let(:secret_path)' }
+
+      let(:full_secret_path) { secret_file(path) }
 
       # Override let(:data) with yaml_data if the secret file is
       # in yaml form


### PR DESCRIPTION
One use-case is on dev machines. Here, you might want to construct
a docker secret out of your existing docker login credentials. There
isn't a need to generate secret when we can just have Matsuri point
directly to it.