### PR TITLE
Added CronJob and updated Pod helpers

### DIFF
--- a/lib/matsuri.rb
+++ b/lib/matsuri.rb
@@ -28,6 +28,7 @@ module Matsuri
     autoload :StatefulSet,             'matsuri/kubernetes/stateful_set'
     autoload :DaemonSet,               'matsuri/kubernetes/daemon_set'
     autoload :Deployment,              'matsuri/kubernetes/deployment'
+    autoload :CronJob,                 'matsuri/kubernetes/cron_job'
 
     autoload :HorizontalPodAutoscaler, 'matsuri/kubernetes/horizontal_pod_autoscaler'
 

--- a/lib/matsuri/cmds/apply.rb
+++ b/lib/matsuri/cmds/apply.rb
@@ -47,6 +47,11 @@ module Matsuri
       apply_cmd_for :deployment, image_tag: true
       map deploy: :deployment
 
+      desc 'cron-job CRONJOB_NAME', 'apply changes to a cronjob'
+      apply_cmd_for :cron_job, image_tag: true
+      map cj: :cron_job
+      map cronjob: :cron_job
+
       desc 'service SERVICE_NAME', 'apply changes to a service'
       apply_cmd_for :service
 

--- a/lib/matsuri/cmds/create.rb
+++ b/lib/matsuri/cmds/create.rb
@@ -51,6 +51,11 @@ module Matsuri
       create_cmd_for :deployment, image_tag: true
       map deploy: :deployment
 
+      desc 'cron-job CRONJOB_NAME', 'apply changes to a cronjob'
+      create_cmd_for :cron_job, image_tag: true
+      map cj: :cron_job
+      map cronjob: :cron_job
+
       desc 'service SERVICE_NAME', 'create a service'
       create_cmd_for :service
 

--- a/lib/matsuri/cmds/delete.rb
+++ b/lib/matsuri/cmds/delete.rb
@@ -39,6 +39,11 @@ module Matsuri
       delete_cmd_for :deployment
       map deploy: :deployment
 
+      desc 'cron-job CRONJOB_NAME', 'apply changes to a cronjob'
+      delete_cmd_for :cron_job
+      map cj: :cron_job
+      map cronjob: :cron_job
+
       desc 'service SERVICE_NAME', 'delete a service'
       delete_cmd_for :service
 

--- a/lib/matsuri/cmds/diff.rb
+++ b/lib/matsuri/cmds/diff.rb
@@ -43,6 +43,11 @@ module Matsuri
       diff_cmd_for :deployment, image_tag: true
       map deploy: :deployment
 
+      desc 'cron-job CRONJOB_NAME', 'apply changes to a cronjob'
+      diff_cmd_for :cron_job, image_tag: true
+      map cj: :cron_job
+      map cronjob: :cron_job
+
       desc 'service SERVICE_NAME', 'diff manifest for service'
       diff_cmd_for :service
 

--- a/lib/matsuri/cmds/show.rb
+++ b/lib/matsuri/cmds/show.rb
@@ -67,6 +67,11 @@ module Matsuri
       show_cmd_for :deployment, image_tag: true
       map deploy: :deployment
 
+      desc 'cron-job CRONJOB_NAME', 'apply changes to a cronjob'
+      show_cmd_for :cron_job, image_tag: true
+      map cj: :cron_job
+      map cronjob: :cron_job
+
       desc 'service SERVICE_NAME', 'show manifest for service'
       show_cmd_for :service
 

--- a/lib/matsuri/concerns/pod_template.rb
+++ b/lib/matsuri/concerns/pod_template.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'yaml'
 require 'active_support/concern'
+require 'active_support/core_ext/hash/compact'
 
 module Matsuri
   module Concerns
@@ -17,12 +18,14 @@ module Matsuri
         # Overide let(:pod_name)
         let(:template) { { metadata: { labels: pod_labels, annotations: pod_annotations }, spec: pod_spec } }
 
-        let(:pod_def)           { pod(pod_name, image_tag: image_tag, release: release) }
-        let(:primary_image)     { pod_def.primary_image }
-        let(:primary_container) { pod_def.primary_container }
-        let(:pod_labels)        { pod_def.final_labels }
-        let(:pod_annotations)   { pod_def.final_annotations }
-        let(:pod_spec)          { pod_def.spec }
+        let(:pod_def)             { pod(pod_name, pod_options) }
+        let(:primary_image)       { pod_def.primary_image }
+        let(:primary_container)   { pod_def.primary_container }
+        let(:pod_labels)          { pod_def.final_labels }
+        let(:pod_annotations)     { pod_def.final_annotations }
+        let(:pod_spec)            { pod_def.spec }
+        let(:pod_options)         { default_pod_options }
+        let(:default_pod_options) { { image_tag: image_tag, release: release } }
       end
 
       ### Helpers

--- a/lib/matsuri/config.rb
+++ b/lib/matsuri/config.rb
@@ -72,6 +72,7 @@ module Matsuri
     default(:replica_sets_path)               { File.join platform_path, 'replica_sets' }
     default(:daemon_sets_path)                { File.join platform_path, 'daemon_sets' }
     default(:deployments_path)                { File.join platform_path, 'deployments' }
+    default(:cron_jobs_path)                  { File.join platform_path, 'cron_jobs' }
     default(:stateful_sets_path)              { File.join platform_path, 'stateful_sets' }
     default(:persistent_volumes_path)         { File.join platform_path, 'persistent_volumes' }
     default(:persistent_volume_claims_path)   { File.join platform_path, 'persistent_volume_claims' }

--- a/lib/matsuri/kubernetes/cron_job.rb
+++ b/lib/matsuri/kubernetes/cron_job.rb
@@ -1,0 +1,113 @@
+require 'active_support/core_ext/hash/compact'
+
+module Matsuri
+  module Kubernetes
+    class CronJob < Matsuri::Kubernetes::Base
+      include Matsuri::Concerns::PodTemplate
+
+      let(:api_version) { 'batch/v1' } # k8s v1.21
+      let(:kind)        { 'CronJob' }  # https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
+
+
+      # Parameters passed from command line
+      let(:image_tag)            { options[:image_tag] || 'latest' }
+
+      # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#cronjobspec-v1-batch
+      let(:spec) do
+        {
+          schedule:                   schedule,
+          time_zone:                  time_zone,
+          suspend:                    suspend,
+          concurrencyPolicy:          concurrency_policy,
+          successfulJobsHistoryLimit: successful_jobs_history_limit,
+          failedJobsHistoryLimit:     failed_jobs_history_limit,
+          startingDeadlineSeconds:    starting_deadline_seconds,
+
+          jobTemplate: {
+            metadata: job_template_metadata,
+            spec: job_template_spec
+          }.compact,
+        }.compact
+      end
+
+      let(:concurrency_policy)            { nil } # 'Allow' | 'Forbid' | 'Replace', default: 'Allow'
+      let(:failed_jobs_history_limit)     { nil } # non-negative integer, default: 1
+      let(:schedule)                      { fail 'Must define let(:schedule)' } # string, cron schedule format
+      let(:starting_deadline_seconds)     { nil } # seconds, integer, optional
+      let(:successful_jobs_history_limit) { nil } # non-negative integer, default: 3
+      let(:suspend)                       { nil } # boolean, default: false
+
+      # k8s v1.27
+      # See: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+      # See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+      let(:time_zone)                     { nil } # string, TZ info, optional
+
+      let(:job_template_metadata)         { { labels: pod_labels, annotations: pod_annotations } }
+
+
+      # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#jobspec-v1-batch
+      let(:job_template_spec) do
+        {
+          selector:                selector,
+          completions:             completions,
+          parallelism:             parallelism,
+          activeDeadlineSeconds:   active_deadline_seconds,
+          ttlSecondsAfterFinished: ttl_seconds_after_finished,
+          backoffLimit:            backoff_limit,
+          managedBy:               managed_by,
+          manualSelector:          manual_selector,
+          podReplacementPolicy:    pod_replacement_policy,
+          suspend:                 job_template_suspend,
+
+          template:                template, # defined in Matsuri::Concerns::PodTemplate
+
+          # Indexed mode (for partitioning jobs), beta as of 1.31
+          completionMode:          completion_mode,
+          backoffLimitPerIndex:    backoff_limit_per_index,
+          maxFailedIndexes:        max_failed_indexes,
+          podFailurePolicy:        pod_failure_policy,
+          successPolicy:           sucess_policy,
+        }
+      end
+
+      let(:active_deadline_seconds)    { nil } # integer
+      let(:backoff_limit)              { nil } # integer, default: 6
+      let(:completions)                { nil } # null | integer
+      let(:managed_by)                 { nil } # null | string
+      let(:manual_selector)            { nil } # null | boolean
+      let(:parallelism)                { nil } # null | integer
+      let(:ttl_seconds_after_finished) { nil } # null | integer
+
+      let(:selector)                   { nil } # This will be autopopulated by cronjob
+      #let(:selector)                   { { matchLabels: match_labels, matchExpressions: match_expressions } }
+      let(:match_labels)               { fail NotImplementedError, 'Must define let(:match_labels)' }
+      let(:match_expressions)          { [] }
+
+      let(:job_template_suspend)       { nil } # boolean, default: false
+
+
+      let(:pod_replacement_policy)     { nil } # 'TerminatingOrFailed' | 'Failed'
+
+      let(:completion_mode)            { nil } # 'NonIndexed' | 'Indexed', default: 'Indexed'
+      let(:backoff_limit_per_index)    { nil } # integer
+      let(:max_failed_indexes)         { nil } # null | integer
+
+      # See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podfailurepolicy-v1-batch
+      let(:pod_failure_policy)         { nil } # null | PodFailurePolicySpec
+
+      # See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#successpolicy-v1-batch
+      let(:sucess_policy)              { nil } # null | SucessPolicySpec
+
+
+      class << self
+        def load_path
+          Matsuri::Config.cron_jobs_path
+        end
+
+        def definition_module_name
+          'CronJobs'
+        end
+      end
+    end
+  end
+end

--- a/lib/matsuri/kubernetes/pod.rb
+++ b/lib/matsuri/kubernetes/pod.rb
@@ -234,8 +234,16 @@ module Matsuri
         }.compact
       end
 
-      def mount(name, path, read_only: false)
-        { name: name, mountPath: path, readOnly: read_only }
+      def mount(name, path, options = {})
+        {
+          name:                name,
+          mountPath:           path,
+          readOnly:            options[:read_only] || false,
+          mountPropogation:    options[:mount_propogation],
+          recursivelyReadOnly: options[:recursively_read_only],
+          subPath:             options[:sub_path],
+          subPathExpr:         options[:sub_path_expr]
+        }.compact
       end
 
       def host_path_volume(name, host_path)

--- a/lib/matsuri/registry.rb
+++ b/lib/matsuri/registry.rb
@@ -159,6 +159,10 @@ module Matsuri
         fetch_or_load :deployment, name
       end
 
+      def cron_job(name)
+        fetch_or_load :cron_job, name
+      end
+
       def persistent_volume(name)
         fetch_or_load :persistent_volume, name
       end
@@ -253,6 +257,7 @@ Matsuri::Registry.register_class 'replica_set',               class: Matsuri::Ku
 Matsuri::Registry.register_class 'stateful_set',              class: Matsuri::Kubernetes::StatefulSet,           aliases: %w[sts]
 Matsuri::Registry.register_class 'daemon_set',                class: Matsuri::Kubernetes::DaemonSet,             aliases: %w[ds]
 Matsuri::Registry.register_class 'deployment',                class: Matsuri::Kubernetes::Deployment
+Matsuri::Registry.register_class 'cron_job',                  class: Matsuri::Kubernetes::CronJob
 Matsuri::Registry.register_class 'persistent_volume',         class: Matsuri::Kubernetes::PersistentVolume, aliases: %w[pv]
 Matsuri::Registry.register_class 'persistent_volume_claim',   class: Matsuri::Kubernetes::PersistentVolumeClaim, aliases: %w[pvc]
 Matsuri::Registry.register_class 'storage_class',             class: Matsuri::Kubernetes::StorageClass


### PR DESCRIPTION

- Added CronJob resources and commands
- Updated pod template helpers to make it easier to reference label selectors from other resources
- Updated volume mount helper for v1.32 parameters